### PR TITLE
Update Irc.coffee / NodeJs Module

### DIFF
--- a/src/client/irc.coffee
+++ b/src/client/irc.coffee
@@ -1,6 +1,6 @@
 # SauceBot IRC Connector
 
-irc  = require '../node/irc'
+irc  = require 'irc'
 util = require 'util'
 io   = require '../common/ioutil'
 time = require '../common/time'


### PR DESCRIPTION
to use the package.json not necessary indicate the route of the IRC class. In this way we avoid the compilation error by not finding the above path on IRC.
